### PR TITLE
Feature/remover recursividad

### DIFF
--- a/lib/i18n/backend/recursive_lookup.rb
+++ b/lib/i18n/backend/recursive_lookup.rb
@@ -27,24 +27,6 @@ module I18n
       def lookup(locale, key, scope = [], options = {})
         result = super
 
-        unless result
-          normalized_key = I18n.normalize_keys(nil, key, scope)
-          return if normalized_key.size < 2
-
-          # simply strip the last key part, e.g.
-          # `foo.bar.baz` becomes `foo.bar`
-          normalized_key.slice!(-1, 1)
-
-          # look the stripped key up - if this is a reference, it will
-          # get compiled and cached
-          lookup(locale, normalized_key, [], options)
-
-          # then try again to get our result - it will be found now if the
-          # previous `lookup` call compiled a new reference with our key,
-          # otherwise still stay nil
-          result = super
-        end
-
         return result unless (result.is_a?(String) or result.is_a?(Hash))
 
         compiled_result, had_to_compile_result = deep_compile(locale, result, options)

--- a/test/backend/recursive_lookup_test.rb
+++ b/test/backend/recursive_lookup_test.rb
@@ -8,55 +8,54 @@ class I18nBackendRecursiveLookupTest < Test::Unit::TestCase
   def setup
     I18n.backend = Backend.new
     I18n.backend.store_translations(:en,
-      :foo => 'foo',
-      :bar => {
-        :baz => 'bar ${foo}',
-        :boo => {
-          :baz => 'hoo ${bar.baz}'
-        }
-      },
-      :alternate_lookup => '${baz}',
-      :hash_lookup => '${hash}',
-      :hash => {
-        one: 'hash',
-        other: 'hashes',
-        deeper: {
-          first: 'First hash',
-          second: 'Second hash'
-        }
-      },
-      :hash_lookup_no_deeper => {
-        :one => 'hash no deep',
-        :other => 'hashes no deep'
-      },
-      :number_hash => {
-        :format => {
-          :delimiter => ',',
-          :precision => 3,
-          :significant => false
-        }
-      }
-    )
+                                    foo: 'foo',
+                                    bar: {
+                                      baz: 'bar ${foo}',
+                                      boo: {
+                                        baz: 'hoo ${bar.baz}'
+                                      }
+                                    },
+                                    alternate_lookup: '${baz}',
+                                    hash_lookup: '${hash}',
+                                    hash: {
+                                      one: 'hash',
+                                      other: 'hashes',
+                                      deeper: {
+                                        first: 'First hash',
+                                        second: 'Second hash'
+                                      }
+                                    },
+                                    hash_lookup_no_deeper: {
+                                      one: 'hash no deep',
+                                      other: 'hashes no deep'
+                                    },
+                                    number_hash: {
+                                      format: {
+                                        delimiter: ',',
+                                        precision: 3,
+                                        significant: false
+                                      }
+                                    })
   end
 
   def teardown
     I18n.backend = nil
   end
 
-  test "still returns an existing translation as usual" do
+  test 'still returns an existing translation as usual' do
     assert_equal 'foo', I18n.t(:foo)
   end
 
-  test "still fails for a missing key" do
-    assert_equal 'translation missing: en.missing_key', I18n.t(:'missing_key')
+  test 'still fails for a missing key' do
+    assert_equal 'translation missing: en.missing_key', I18n.t(:missing_key)
   end
 
-  test "does a lookup on an embedded key" do
+  test 'does a lookup on an embedded key' do
     assert_equal 'bar foo', I18n.t(:'bar.baz')
     assert_equal 'hoo bar foo', I18n.t(:'bar.boo.baz')
   end
 
-  test "stores a compiled lookup" do
+  test 'stores a compiled lookup' do
     original_lookup = I18n::Backend::Simple.instance_method(:lookup).bind(I18n.backend)
 
     result = I18n.t(:'bar.baz')
@@ -64,15 +63,16 @@ class I18nBackendRecursiveLookupTest < Test::Unit::TestCase
     assert_equal result, precompiled_result
   end
 
-  test "resolves hash lookups" do
+  test 'resolves hash lookups' do
     assert_equal I18n.t(:'bar.boo').to_s, '{:baz=>"hoo bar foo"}'
   end
 
   test 'handles non-string results from lookup' do
-    assert_equal '{:delimiter=>",", :precision=>3, :significant=>false}', I18n.t(:'number_hash.format', :locale => :en, :default => {}).to_s
+    assert_equal '{:delimiter=>",", :precision=>3, :significant=>false}',
+                 I18n.t(:'number_hash.format', locale: :en, default: {}).to_s
   end
 
-  test "stores a compiled hash lookup" do
+  test 'stores a compiled hash lookup' do
     original_lookup = I18n::Backend::Simple.instance_method(:lookup).bind(I18n.backend)
 
     result = I18n.t(:'bar.boo')
@@ -80,34 +80,26 @@ class I18nBackendRecursiveLookupTest < Test::Unit::TestCase
     assert_equal result, precompiled_result
   end
 
-  test "correctly returns a hash" do
-    result = I18n.t(:'hash_lookup')
+  test 'correctly returns a hash' do
+    result = I18n.t(:hash_lookup)
 
     assert_equal Hash, result.class
 
     assert_equal({
-      one: 'hash',
-      other: 'hashes',
-      deeper: {
-        first: 'First hash',
-        second: 'Second hash'
-      }
-    }, result)
+                   one: 'hash',
+                   other: 'hashes',
+                   deeper: {
+                     first: 'First hash',
+                     second: 'Second hash'
+                   }
+                 }, result)
   end
 
-  test "correctly translates a hash reference with count" do
+  test 'correctly translates a hash reference with count' do
     assert_equal 'hashes no deep', I18n.t(:hash_lookup_no_deeper, count: 5)
   end
 
-  test "correctly translates a hash reference when called directly" do
-    assert_equal 'hashes', I18n.t(:'hash_lookup.other')
-  end
-
-  test "correctly translates a hash reference when called directly even when nested" do
-    assert_equal 'Second hash', I18n.t(:'hash_lookup.deeper.second')
-  end
-
-  test "correctly fails for a hash reference that is not present" do
+  test 'correctly fails for a hash reference that is not present' do
     assert_equal 'translation missing: en.hash_lookup.deeper.not_there.really',
                  I18n.t(:'hash_lookup.deeper.not_there.really')
   end
@@ -122,21 +114,20 @@ class I18nBackendRecursiveLookupWithoutCacheTest < Test::Unit::TestCase
     I18n.backend = Backend.new
     I18n.backend.disable_interpolation_cache
     I18n.backend.store_translations(:en,
-      :foo => 'foo',
-      :bar => {
-        :baz => 'bar ${foo}',
-        :boo => {
-          :baz => 'hoo ${bar.baz}'
-        }
-      }
-    )
+                                    foo: 'foo',
+                                    bar: {
+                                      baz: 'bar ${foo}',
+                                      boo: {
+                                        baz: 'hoo ${bar.baz}'
+                                      }
+                                    })
   end
 
   def teardown
     I18n.backend = nil
   end
 
-  test "recursive translation of a hash with cache disabled" do
+  test 'recursive translation of a hash with cache disabled' do
     assert_equal({
                    baz: 'bar foo',
                    boo: {
@@ -152,17 +143,16 @@ class I18nBackendRecursiveLookupWithoutCacheTest < Test::Unit::TestCase
                  }, I18n.backend.send(:translations)[:en][:bar])
   end
 
-  test "recursive translation of a string with cache disabled" do
+  test 'recursive translation of a string with cache disabled' do
     assert_equal 'bar foo', I18n.t(:'bar.baz')
     assert_equal 'bar ${foo}', I18n.backend.send(:translations)[:en][:bar][:baz]
   end
 
-  test "correctly reevaluates translations" do
+  test 'correctly reevaluates translations' do
     assert_equal 'bar foo', I18n.t(:'bar.baz')
 
     I18n.backend.store_translations(:en,
-      :foo => 'new_foo',
-    )
+                                    foo: 'new_foo')
 
     assert_equal 'bar new_foo', I18n.t(:'bar.baz')
   end


### PR DESCRIPTION
Como solo nos interesa el poder referenciar otros elementos, se elimina la recursividad para hacerlo más eficiente.