### PR TITLE
chore: corregir clonacion de hash de traducciones para soportar ruby 3.2.1

### DIFF
--- a/lib/i18n/backend/recursive_lookup.rb
+++ b/lib/i18n/backend/recursive_lookup.rb
@@ -41,7 +41,7 @@ module I18n
       #subject is hash or string
       def deep_compile(locale, subject, options)
         # Prevent modifying the original hash if cache is not enabled
-        subject = subject.clone unless enable_interpolation_cache?
+        subject = subject&.dup unless enable_interpolation_cache?
 
         if subject.is_a?(Hash)
           subject.each do |key, object|


### PR DESCRIPTION
# Problema

En nuevas versiones de ruby (3.2.1),la traducción recursiva está fallando al recibir un hash con el siguiente error: 
```
versions/3.2.1/lib/ruby/gems/3.2.0/bundler/gems/i18n-recursive-lookup-1348a7db9f7c/lib/i18n/backend/recursive_lookup.rb:48:in `block in deep_compile': can't modify frozen Hash: {:one=>"Trabajo", :other=>"Trabajos"} (FrozenError) `
```
# Contexto

* `i18n-recursive-lookup` depende de `i18n`, que depende `psych`
* Desde la [versión 3.1 de ruby, `psych` paso a la versión 4.0](https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/), la cual modifica el funcionamiento de _safe_load_, afectando a `i18n`
* `i18n` incorporó soporte para ambas versiones de `psych` (mayor y menor a 4.0) desde `i18n` [version 1.8.11](https://github.com/ruby-i18n/i18n/releases), pero también agregó un `freeze` al cargado de yml cargado

# Motivo del problema

El problema llega a que al hacer `clone` del `hash` a traducir, se copia tambien si está `frozen` o no, lo cual genera problemas más adelante cuando se quiere modificar la copia. 

# Solución propuesta

Ante este problema se propone cambiar el `clone` por un `dup`, ya que este no copia el estado de `frozen`. 

También se intentó `.clone(freeze: false)` pero en algunos casos lanzaba el error `ArgumentError: can't unfreeze Integer`, lo cual no ocurre al utilizar dup. 

El uso del `safe_navigator` es en caso de que llegue un nil a traducir.

# Cómo probar

- Descargar la rama y correr bundle install
- Ejecutar `ruby -Itest test/backend/recursive_lookup_test.rb`
<img width="980" alt="image" src="https://github.com/bukhr/i18n-recursive-lookup/assets/31098533/da18f2eb-3c5f-4565-b2cb-fc30aef7fd6d">

