### PR TITLE
hotfix: re-entrar en la cadena de fallbacks al referenciar una traduccion 

### DIFF
--- a/lib/i18n/backend/recursive_lookup.rb
+++ b/lib/i18n/backend/recursive_lookup.rb
@@ -61,7 +61,7 @@ module I18n
 
             if embedded_token
               had_to_compile_result = true
-              handle_interpolation_match(locale, embedded_token, options)
+              handle_interpolation_match(embedded_token)
             else
               token
             end
@@ -91,9 +91,11 @@ module I18n
         store_translations(locale, translation_hash, options)
       end
 
-      def handle_interpolation_match(locale, embedded_token, options)
+      def handle_interpolation_match(embedded_token)
         escaped, pattern, key = embedded_token.values_at(1, 2, 3)
-        escaped ? pattern : I18n.translate(key, locale: locale)
+        # don't call translate with the locale passed by the functions because it could be one of the fallbacks
+        # it should always re-enter the lookup process with the current locale setted in I18n.locale
+        escaped ? pattern : I18n.translate(key)
       end
     end
   end


### PR DESCRIPTION
Teniamos el problema de que si referenciabamos una traduccion con el locale de un pais, si la traduccion no estaba en este locale, caia a los fallbacks que internamente setean el locale al fallback como tal, luego la traduccion referenciada no entraba a la cadena de fallbacks, si no que quedaba en la actual, quedando la traducción erronea

Esto se puede ver en el test creado, donde si se retiran los cambios a la función `handle_interpolation_match` quedan con la traduccion mal.

Para correr los test se hace con `rake test`