### PR TITLE
feat: añadir soporte para arrays en deep_compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,84 @@
-I18n Recursive Lookup ![Build status](https://api.travis-ci.org/annkissam/i18n-recursive-lookup.png)
-=====================
+# I18n Recursive Lookup ![Build status](https://api.travis-ci.org/annkissam/i18n-recursive-lookup.png)
 
 Provides a backend to the i18n gem to allow a definition to contain embedded references to other definitions by introducing the special embedded marker `${}`.
 
 All definitions are lazily evaluated on lookup, and once compiled they're written back to the translation store so that all interpolation happens once.
 
-### Example
+Supports recursive lookups in **strings**, **hashes**, and **arrays**.
 
-    # example.yml
-    foo:
-        bar: boo
-    baz: ${foo.bar}
+## Examples
+
+### String interpolation
+
+```yml
+foo:
+  bar: boo
+baz: ${foo.bar}
+```
 
 `I18n.t(:baz)` will correctly evaluate to `boo`.
 
-### Installation
+### Hash recursion
+
+```yml
+messages:
+  greeting: "Hello ${user.name}"
+  farewell: "Goodbye ${user.name}"
+user:
+  name: "Alice"
+```
+
+`I18n.t(:messages)` will return: `{ greeting: "Hello Alice", farewell: "Goodbye Alice" }`.
+
+### Array interpolation
+
+```yml
+foo: world
+greetings:
+  - "Hello ${foo}"
+  - "Goodbye ${foo}"
+```
+
+`I18n.t(:greetings)` will correctly evaluate to `["Hello world", "Goodbye world"]`.
+
+### Nested structures
+
+```yml
+base: "value"
+nested:
+  items:
+    - "Item: ${base}"
+    - "Another: ${base}"
+  data:
+    key: "${base}"
+```
+
+All nested arrays and hashes will be recursively processed with embedded references resolved.
+
+## Installation
 
 Install the gem either by putting it in your `Gemfile`
 
-    gem 'i18n-recursive-lookup'
+```bash
+gem 'i18n-recursive-lookup'
+```
+
 or by installing it using rubygems
 
-    gem install i18n-recursive-lookup
+```bash
+gem install i18n-recursive-lookup
+```
 
 Add it to your existing backend by adding these lines to your `config/initializers/i18n.rb` (create one if one doesn't exist):
 
-    # config/initializers/i18n.rb
-    require 'i18n/backend/recursive_lookup'
-    I18n::Backend::Simple.send(:include, I18n::Backend::RecursiveLookup)
+```ruby
+# config/initializers/i18n.rb
+require 'i18n/backend/recursive_lookup'
+I18n::Backend::Simple.send(:include, I18n::Backend::RecursiveLookup)
+```
 
 Of course you can replace the `I18n::Backend::Simple` with whatever backend you wish to use.
 
-### TODO
+## TODO
+
 - add detection for infinite embedding cycles

--- a/lib/i18n-recursive-lookup/version.rb
+++ b/lib/i18n-recursive-lookup/version.rb
@@ -1,5 +1,5 @@
 module I18n
   module RecursiveLookup
-    VERSION = "0.0.6"
+    VERSION = "0.0.7"
   end
 end

--- a/lib/i18n/backend/recursive_lookup.rb
+++ b/lib/i18n/backend/recursive_lookup.rb
@@ -27,7 +27,7 @@ module I18n
       def lookup(locale, key, scope = [], options = {})
         result = super
 
-        return result unless (result.is_a?(String) or result.is_a?(Hash))
+        return result unless (result.is_a?(String) or result.is_a?(Hash) or result.is_a?(Array))
 
         compiled_result, had_to_compile_result = deep_compile(locale, result, options)
 
@@ -38,7 +38,7 @@ module I18n
         compiled_result
       end
 
-      #subject is hash or string
+      #subject is hash, array or string
       def deep_compile(locale, subject, options)
         # Prevent modifying the original hash if cache is not enabled
         subject = subject&.dup unless enable_interpolation_cache?
@@ -47,6 +47,14 @@ module I18n
           subject.each do |key, object|
             subject[key], _had_to_compile_result = deep_compile(locale, object, options)
           end
+        elsif subject.is_a?(Array)
+          had_any = false
+          subject = subject.map do |element|
+            compiled, had = deep_compile(locale, element, options)
+            had_any ||= had
+            compiled
+          end
+          [subject, had_any]
         else
           compile(locale, subject, options)
         end

--- a/test/backend/recursive_lookup_test.rb
+++ b/test/backend/recursive_lookup_test.rb
@@ -35,7 +35,10 @@ class I18nBackendRecursiveLookupTest < Test::Unit::TestCase
                                         precision: 3,
                                         significant: false
                                       }
-                                    })
+                                    },
+                                    simple_list: ['item 1', 'item 2', 'item 3'],
+                                    list_with_interpolation: ['hello ${foo}', 'goodbye ${foo}'],
+                                    nested_array: { items: ['value 1', 'value 2'] })
   end
 
   def teardown
@@ -47,7 +50,7 @@ class I18nBackendRecursiveLookupTest < Test::Unit::TestCase
   end
 
   test 'still fails for a missing key' do
-    assert_equal 'translation missing: en.missing_key', I18n.t(:missing_key)
+    assert_equal 'Translation missing: en.missing_key', I18n.t(:missing_key)
   end
 
   test 'does a lookup on an embedded key' do
@@ -100,8 +103,34 @@ class I18nBackendRecursiveLookupTest < Test::Unit::TestCase
   end
 
   test 'correctly fails for a hash reference that is not present' do
-    assert_equal 'translation missing: en.hash_lookup.deeper.not_there.really',
+    assert_equal 'Translation missing: en.hash_lookup.deeper.not_there.really',
                  I18n.t(:'hash_lookup.deeper.not_there.really')
+  end
+
+  test 'returns a simple array' do
+    result = I18n.t(:simple_list)
+    assert_equal Array, result.class
+    assert_equal ['item 1', 'item 2', 'item 3'], result
+  end
+
+  test 'processes array with interpolation' do
+    result = I18n.t(:list_with_interpolation)
+    assert_equal Array, result.class
+    assert_equal ['hello foo', 'goodbye foo'], result
+  end
+
+  test 'processes nested array within hash' do
+    result = I18n.t(:nested_array)
+    assert_equal Hash, result.class
+    assert_equal({ items: ['value 1', 'value 2'] }, result)
+  end
+
+  test 'stores a compiled array lookup' do
+    original_lookup = I18n::Backend::Simple.instance_method(:lookup).bind(I18n.backend)
+
+    result = I18n.t(:list_with_interpolation)
+    precompiled_result = original_lookup.call(:en, :list_with_interpolation)
+    assert_equal result, precompiled_result
   end
 end
 
@@ -120,7 +149,8 @@ class I18nBackendRecursiveLookupWithoutCacheTest < Test::Unit::TestCase
                                       boo: {
                                         baz: 'hoo ${bar.baz}'
                                       }
-                                    })
+                                    },
+                                    list_with_interpolation: ['hello ${foo}', 'goodbye ${foo}'])
   end
 
   def teardown
@@ -155,6 +185,13 @@ class I18nBackendRecursiveLookupWithoutCacheTest < Test::Unit::TestCase
                                     foo: 'new_foo')
 
     assert_equal 'bar new_foo', I18n.t(:'bar.baz')
+  end
+
+  test 'recursive translation of an array with cache disabled' do
+    assert_equal(['hello foo', 'goodbye foo'], I18n.t(:list_with_interpolation))
+
+    assert_equal(['hello ${foo}', 'goodbye ${foo}'],
+                 I18n.backend.send(:translations)[:en][:list_with_interpolation])
   end
 end
 


### PR DESCRIPTION
Añadir soporte para manejar arrays en método `deep_compile`, para poder acceder a traducciones cuando la key del archivo locale almacene una lista en lugar de solo strings o hashes